### PR TITLE
Monitor size of game-creator logs

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -5,6 +5,26 @@ input {
     	type => "game-creator"
     }
 
+    http_poller {
+	urls => {
+		eshost => "http://elasticsearch:9200/game-creator-index/_stats/store"
+	}
+	interval => 3600
+	type => "db-size"
+	codec => "json"
+	metadata_target => http_poller_metadata
+    }
+}
+
+filter {
+	if [type] == "db-size" {
+		mutate {
+			rename => {
+				"_all" => "tot"
+			}
+			remove_field => [http_poller_metadata]
+		}
+	}
 }
 
 output {

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -2,12 +2,14 @@ input {
     tcp {
         port => 4560
     	codec => "json"
-    	add_field => {"component" => "game-creator"}
+    	type => "game-creator"
     }
+
 }
 
 output {
     elasticsearch {
     	hosts => ["elasticsearch"]
+	index => "%{type}-index"
     }
 }


### PR DESCRIPTION
Every hour logstash will query elasticsearch to obtain the size of the game-creator database (in elasticsearch jargon *index*). This information is then stored in a specific elasticsearch index that we can monitor from the kibana dashboard.