### PR TITLE
Use tested version of elasticstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,12 +63,12 @@ services:
       - data
 
   elasticsearch:
-    image: elasticsearch:latest
+    image: elasticsearch:2.4.1
     volumes_from:
       - data
 
   kibana:
-    image: kibana:latest
+    image: kibana:4.6.2
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
       - SERVER_HOST=kibana

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,3 +1,3 @@
-FROM logstash:latest
+FROM logstash:2.4.0
 
 COPY ./logstash.conf /config/logstash.conf


### PR DESCRIPTION
The elasticstack (elasticsearch, logstash, kibana) received a major upgrade: version 5.0 is available.
As there are some breaking changes, this PR forces docker to use the version of the stack we know to work.

When testing will be complete, we will manually (change the versions in `docker-compose.yml` and `logstash/Dockerfile`) upgrade to the newer version of the stack